### PR TITLE
Make sure createNavigationContainer is mounted before updating state

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,6 @@
     "@react-navigation/core": "^3.0.0-alpha",
     "react": "*",
     "react-native": "*",
-    "react-native-gesture-handler": "^1.0.0",
-    "react-native-reanimated": "^1.0.0 || ^1.0.0-alpha",
-    "react-native-screens": "^1.0.0 || ^1.0.0-alpha"
   },
   "jest": {
     "preset": "react-native",
@@ -91,6 +88,9 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.0.1",
-    "react-native-safe-area-view": "^0.11.0"
+    "react-native-safe-area-view": "^0.11.0",
+    "react-native-gesture-handler": "^1.0.0",
+    "react-native-reanimated": "^1.0.0 || ^1.0.0-alpha",
+    "react-native-screens": "^1.0.0 || ^1.0.0-alpha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
     "@react-navigation/core": "^3.0.0-alpha",
     "react": "*",
     "react-native": "*",
+    "react-native-gesture-handler": "^1.0.0",
+    "react-native-reanimated": "^1.0.0 || ^1.0.0-alpha",
+    "react-native-screens": "^1.0.0 || ^1.0.0-alpha"
   },
   "jest": {
     "preset": "react-native",
@@ -88,9 +91,6 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.0.1",
-    "react-native-safe-area-view": "^0.11.0",
-    "react-native-gesture-handler": "^1.0.0",
-    "react-native-reanimated": "^1.0.0 || ^1.0.0-alpha",
-    "react-native-screens": "^1.0.0 || ^1.0.0-alpha"
+    "react-native-safe-area-view": "^0.11.0"
   }
 }

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -344,12 +344,14 @@ export default function createNavigationContainer(Component) {
       if (navState !== lastNavState) {
         // Cache updates to state.nav during the tick to ensure that subsequent calls will not discard this change
         this._navState = navState;
-        this.setState({ nav: navState }, () => {
-          this._onNavigationStateChange(lastNavState, navState, action);
-          dispatchActionEvents();
-          this._persistNavigationState(navState);
-        });
-        return true;
+        if (this._isMounted) {
+          this.setState({ nav: navState }, () => {
+            this._onNavigationStateChange(lastNavState, navState, action);
+            dispatchActionEvents();
+            this._persistNavigationState(navState);
+          });
+          return true;
+        }
       }
 
       dispatchActionEvents();


### PR DESCRIPTION
Gets rid of warnings and makes sure there are no memory leaks.

My app was always throwing warnings when navigating between navigators in a SwitchNavigator, because the container component tried to call setState after it was already unmounted. This small fix gets rid of my warnings.