### PR TITLE
add ability to use custom state persistence fn

### DIFF
--- a/src/Scrollables.js
+++ b/src/Scrollables.js
@@ -1,5 +1,11 @@
 import React from 'react';
-import { ScrollView, Platform, FlatList, SectionList, RefreshControl } from 'react-native';
+import {
+  ScrollView,
+  Platform,
+  FlatList,
+  SectionList,
+  RefreshControl,
+} from 'react-native';
 import { ScrollView as GHScrollView } from 'react-native-gesture-handler';
 import createNavigationAwareScrollable from './createNavigationAwareScrollable';
 import invariant from './utils/invariant';

--- a/src/__tests__/createAppContainer-test.js
+++ b/src/__tests__/createAppContainer-test.js
@@ -279,12 +279,10 @@ describe('NavigationContainer', () => {
   describe('state persistence', () => {
     it('loadNavigationState is called upon mount and persistNavigationState is called on a nav state change', async () => {
       const persistNavigationState = jest.fn();
-      const loadNavigationState = jest.fn().mockResolvedValue(
-        JSON.stringify({
-          index: 1,
-          routes: [{ routeName: 'foo' }, { routeName: 'bar' }],
-        })
-      );
+      const loadNavigationState = jest.fn().mockResolvedValue({
+        index: 1,
+        routes: [{ routeName: 'foo' }, { routeName: 'bar' }],
+      });
 
       const navigationContainer = renderer
         .create(

--- a/src/__tests__/createAppContainer-test.js
+++ b/src/__tests__/createAppContainer-test.js
@@ -277,9 +277,7 @@ describe('NavigationContainer', () => {
   const flushPromises = () => new Promise(resolve => setImmediate(resolve));
 
   describe('state persistence', () => {
-    const persistenceKey = 'persistenceKey';
-
-    it('on a nav state change, persistNavigationState is called with state and persistence key', async () => {
+    it('loadNavigationState is called upon mount and persistNavigationState is called on a nav state change', async () => {
       const persistNavigationState = jest.fn();
       const loadNavigationState = jest.fn().mockResolvedValue(
         JSON.stringify({
@@ -293,13 +291,12 @@ describe('NavigationContainer', () => {
           <NavigationContainer
             persistNavigationState={persistNavigationState}
             loadNavigationState={loadNavigationState}
-            persistenceKey={persistenceKey}
           />
         )
         .getInstance();
       // wait for the loadNavigationState() to resolve
       await flushPromises();
-      expect(loadNavigationState).toHaveBeenCalledWith(persistenceKey);
+      expect(loadNavigationState).toHaveBeenCalled();
 
       // wait for setState done
       jest.runOnlyPendingTimers();
@@ -308,10 +305,19 @@ describe('NavigationContainer', () => {
         NavigationActions.navigate({ routeName: 'foo' })
       );
       jest.runOnlyPendingTimers();
-      expect(persistNavigationState).toHaveBeenCalledWith(
-        { index: 0, isTransitioning: true, routes: [{ routeName: 'foo' }] },
-        persistenceKey
-      );
+      expect(persistNavigationState).toHaveBeenCalledWith({
+        index: 0,
+        isTransitioning: true,
+        routes: [{ routeName: 'foo' }],
+      });
+    });
+
+    it('throws when persistNavigationState and loadNavigationState do not pass validation', () => {
+      expect(() =>
+        renderer.create(
+          <NavigationContainer persistNavigationState={jest.fn()} />
+        )
+      ).toThrow();
     });
   });
 });

--- a/src/__tests__/createAppContainer-test.js
+++ b/src/__tests__/createAppContainer-test.js
@@ -322,6 +322,30 @@ describe('NavigationContainer', () => {
       });
     });
 
+    it('when persistNavigationState rejects, a console warning is shown', async () => {
+      const consoleSpy = jest.spyOn(console, 'warn');
+      const persistNavigationState = jest
+        .fn()
+        .mockRejectedValue(new Error('serialization failed'));
+      const loadNavigationState = jest.fn().mockResolvedValue(null);
+
+      const navigationContainer = await createPersistenceEnabledContainer(
+        loadNavigationState,
+        persistNavigationState
+      );
+
+      // wait for setState done
+      jest.runOnlyPendingTimers();
+
+      navigationContainer.dispatch(
+        NavigationActions.navigate({ routeName: 'baz' })
+      );
+      jest.runOnlyPendingTimers();
+      await flushPromises();
+
+      expect(consoleSpy).toHaveBeenCalledWith(expect.any(String));
+    });
+
     it('when loadNavigationState rejects, navigator ignores the rejection and starts from the initial state', async () => {
       const loadNavigationState = jest
         .fn()

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -37,6 +37,13 @@ function validateProps(props) {
   }
 }
 
+function defaultNavigationStatePersister = async (navState, persistenceKey) => {
+  if (!persistenceKey) {
+    return;
+  }
+  await AsyncStorage.setItem(persistenceKey, JSON.stringify(navState));
+};
+
 // Track the number of stateful container instances. Warn if >0 and not using the
 // detached prop to explicitly acknowledge the behavior. We should deprecated implicit
 // stateful navigation containers in a future release and require a provider style pattern
@@ -70,6 +77,10 @@ export default function createNavigationContainer(Component) {
     static getDerivedStateFromProps(nextProps) {
       validateProps(nextProps);
       return null;
+    }
+
+    static defaultProps = {
+      persistNavigationState: defaultNavigationStatePersister
     }
 
     _actionEventSubscribers = new Set();
@@ -294,10 +305,7 @@ export default function createNavigationContainer(Component) {
 
     _persistNavigationState = async nav => {
       const { persistenceKey } = this.props;
-      if (!persistenceKey) {
-        return;
-      }
-      await AsyncStorage.setItem(persistenceKey, JSON.stringify(nav));
+      await this.props.persistNavigationState(nav, persistenceKey)
     };
 
     componentWillUnmount() {

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -16,6 +16,14 @@ function isStateful(props) {
 }
 
 function validateProps(props) {
+  if (props.persistenceKey) {
+    console.warn(
+      'You passed persistenceKey prop to a navigator. ' +
+        'The persistenceKey prop was replaced by a more flexible persistence mechanism, ' +
+        'please see the navigation state persistence docs for more information. ' +
+        'Passing the persistenceKey prop is a no-op.'
+    );
+  }
   if (isStateful(props)) {
     return;
   }
@@ -48,14 +56,6 @@ function validateProps(props) {
         typeof loadNavigationState === 'function'),
     'both persistNavigationState and loadNavigationState must either be undefined, or be functions'
   );
-  if (props.persistenceKey) {
-    console.warn(
-      'You passed persistenceKey prop to a navigator. ' +
-        'The persistenceKey prop was replaced by a more flexible persistence mechanism, ' +
-        'please see the navigation state persistence docs for more information. ' +
-        'Passing the persistenceKey prop is a no-op.'
-    );
-  }
 }
 
 // Track the number of stateful container instances. Warn if >0 and not using the

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -307,7 +307,7 @@ export default function createNavigationContainer(Component) {
     _persistNavigationState = async nav => {
       const { persistNavigationState } = this.props;
       if (persistNavigationState) {
-        await this.props.persistNavigationState(nav);
+        await persistNavigationState(nav);
       }
     };
 

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -48,6 +48,14 @@ function validateProps(props) {
         typeof loadNavigationState === 'function'),
     'both persistNavigationState and loadNavigationState must either be undefined, or be functions'
   );
+  if (props.persistenceKey) {
+    console.warn(
+      'You passed persistenceKey prop to a navigator. ' +
+        'The persistenceKey prop was replaced by a more flexible persistence mechanism, ' +
+        'please see the navigation state persistence docs for more information. ' +
+        'Passing the persistenceKey prop is a no-op.'
+    );
+  }
 }
 
 // Track the number of stateful container instances. Warn if >0 and not using the

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -221,14 +221,14 @@ export default function createNavigationContainer(Component) {
       // Pull out anything that can impact state
       const { uriPrefix, enableURLHandling, loadNavigationState } = this.props;
       let parsedUrl = null;
-      let deserializedStartupState = null;
+      let userProvidedStartupState = null;
       if (enableURLHandling !== false) {
         const [url, loadedNavState] = await Promise.all([
           Linking.getInitialURL(),
           loadNavigationState && loadNavigationState(),
         ]);
         parsedUrl = url && urlToPathAndParams(url, uriPrefix);
-        deserializedStartupState = loadedNavState;
+        userProvidedStartupState = loadedNavState;
       }
 
       // Initialize state. This must be done *after* any async code
@@ -243,8 +243,8 @@ export default function createNavigationContainer(Component) {
       }
 
       // Pull user-provided persisted state
-      if (deserializedStartupState) {
-        startupState = deserializedStartupState;
+      if (userProvidedStartupState) {
+        startupState = userProvidedStartupState;
         _reactNavigationIsHydratingState = true;
       }
 

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -317,7 +317,7 @@ export default function createNavigationContainer(Component) {
       if (_reactNavigationIsHydratingState) {
         _reactNavigationIsHydratingState = false;
         console.warn(
-          'Uncaught exception while starting app from persisted navigation state! Trying to render again with a fresh navigation state..'
+          'Uncaught exception while starting app from persisted navigation state! Trying to render again with a fresh navigation state...'
         );
         this.dispatch(NavigationActions.init());
       } else {
@@ -328,7 +328,13 @@ export default function createNavigationContainer(Component) {
     _persistNavigationState = async nav => {
       const { persistNavigationState } = this.props;
       if (persistNavigationState) {
-        await persistNavigationState(nav);
+        try {
+          await persistNavigationState(nav);
+        } catch (err) {
+          console.warn(
+            'Uncaught exception while calling persistNavigationState()! You should handle exceptions thrown from persistNavigationState(), ignoring them may result in undefined behavior.'
+          );
+        }
       }
     };
 


### PR DESCRIPTION
motivation: our app, historically, does not always have JSON-serializable navigation params.

Some of our params are instances of classes that, when you do `JSON.stringify(param)`, the call does not throw, but the resulting JSON loses some information and the original instance cannot be recovered. So it seems like the state was serialized successfully, but after a reload, the screens do not have their correct nav params, causing a crash. 

I'd like to be able to specify custom serialization fn so that we can serialize only the state we want.

As a side effect, I also added `loadNavigationState` which helps remove dependency on AsyncStorage (#17) and allows to modify the recovered nav state object.