### PR TITLE
fix: support platforms without BackHandler

### DIFF
--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -81,7 +81,7 @@ export default function createNavigationContainer(Component) {
 
       this._initialAction = NavigationActions.init();
 
-      if (this._isStateful()) {
+      if (this._isStateful() && BackHandler && typeof BackHandler.addEventListener === 'function') {
         this.subs = BackHandler.addEventListener('hardwareBackPress', () => {
           if (!this._isMounted) {
             this.subs && this.subs.remove();

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -81,7 +81,11 @@ export default function createNavigationContainer(Component) {
 
       this._initialAction = NavigationActions.init();
 
-      if (this._isStateful() && BackHandler && typeof BackHandler.addEventListener === 'function') {
+      if (
+        this._isStateful() &&
+        BackHandler &&
+        typeof BackHandler.addEventListener === 'function'
+      ) {
         this.subs = BackHandler.addEventListener('hardwareBackPress', () => {
           if (!this._isMounted) {
             this.subs && this.subs.remove();


### PR DESCRIPTION
Adds a check against `BackHandler`, before calling `BackHandler.addEventListener`, in order to support running on React Native platforms that do not implement it.