### PR TITLE
pass onTransitionStart's return value back to caller

### DIFF
--- a/src/createKeyboardAwareNavigator.js
+++ b/src/createKeyboardAwareNavigator.js
@@ -52,7 +52,7 @@ export default (Navigator, navigatorConfig) =>
 
       const onTransitionStart =
         this.props.onTransitionStart || navigatorConfig.onTransitionStart;
-      onTransitionStart &&
+      return onTransitionStart &&
         onTransitionStart(transitionProps, prevTransitionProps);
     };
   };


### PR DESCRIPTION
Use case: If we want to wait for an async call to complete before proceeding with the navigation

Transitioner checks to see if value is promise, and if so it waits.
https://github.com/react-navigation/stack/blob/676bc3b45a7715edecd13530ae3b39ee1fe48833/src/views/Transitioner.tsx#L204

